### PR TITLE
fix mem leaks of module transport

### DIFF
--- a/yar.c
+++ b/yar.c
@@ -115,6 +115,7 @@ PHP_MSHUTDOWN_FUNCTION(yar)
 	YAR_SHUTDOWN(service);
 	YAR_SHUTDOWN(packager);
 
+	YAR_SHUTDOWN(transport);
 	return SUCCESS;
 }
 /* }}} */


### PR DESCRIPTION
Wow, here I am again.
yar memory leaks, you forget to SHUTDOWN transport module.
```
yar git:(php7) ✗ valgrind --leak-check=full php7 -r "echo 'George';"
==10053== Memcheck, a memory error detector
==10053== Copyright (C) 2002-2012, and GNU GPL'd, by Julian Seward et al.
==10053== Using Valgrind-3.8.1 and LibVEX; rerun with -h for copyright info
==10053== Command: php7 -r echo\ 'George';
==10053==
George==10053==
==10053== HEAP SUMMARY:
==10053==     in use at exit: 2,533 bytes in 25 blocks
==10053==   total heap usage: 12,359 allocs, 12,334 frees, 1,640,436 bytes allocated
==10053==
==10053== 40 bytes in 1 blocks are definitely lost in loss record 19 of 25
==10053==    at 0x4C27A2E: malloc (vg_replace_malloc.c:270)
==10053==    by 0xD2E00D1: ???
==10053==    by 0xD2E01A3: ???
==10053==    by 0xD2D7295: ???
==10053==    by 0x832E1C: zend_startup_module_ex (zend_API.c:1854)
==10053==    by 0x832E7E: zend_startup_module_zval (zend_API.c:1869)
==10053==    by 0x840821: zend_hash_apply (zend_hash.c:1437)
==10053==    by 0x833438: zend_startup_modules (zend_API.c:1980)
==10053==    by 0x7966DA: php_module_startup (main.c:2198)
==10053==    by 0x8F4CEC: php_cli_startup (php_cli.c:423)
==10053==    by 0x8F6E2E: main (php_cli.c:1318)
==10053==
==10053== LEAK SUMMARY:
==10053==    definitely lost: 40 bytes in 1 blocks
==10053==    indirectly lost: 0 bytes in 0 blocks
==10053==      possibly lost: 0 bytes in 0 blocks
==10053==    still reachable: 2,493 bytes in 24 blocks
==10053==         suppressed: 0 bytes in 0 blocks
==10053== Reachable blocks (those to which a pointer was found) are not shown.
==10053== To see them, rerun with: --leak-check=full --show-reachable=yes
==10053==
==10053== For counts of detected and suppressed errors, rerun with: -v
==10053== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 6 from 6)