### PR TITLE
delete the redundant code

### DIFF
--- a/yar_protocol.c
+++ b/yar_protocol.c
@@ -50,7 +50,6 @@ yar_header_t * php_yar_protocol_parse(char *payload) /* {{{ */ {
 	header->magic_num = ntohl(header->magic_num);
 
 	if (header->magic_num != YAR_PROTOCOL_MAGIC_NUM) {
-		header->magic_num = htonl(header->magic_num);
 		return NULL;
 	}
 


### PR DESCRIPTION
If the magic_num not equal YAR_PROTOCOL_MAGIC_NUM. the return null, and don't need the code
"header->magic_num = htonl(header->magic_num);", I think.
