### PR TITLE
Replace uint with unsigned

### DIFF
--- a/transports/curl.c
+++ b/transports/curl.c
@@ -359,7 +359,7 @@ static void php_yar_curl_prepare(yar_transport_interface_t* self) /* {{{ */ {
 
 yar_response_t *php_yar_curl_exec(yar_transport_interface_t* self, yar_request_t *request) /* {{{ */ {
 	char *msg;
-	uint len;
+	unsigned len;
 	CURLcode ret;
 	yar_response_t *response;
 	yar_curl_data_t *data = (yar_curl_data_t *)self->data;
@@ -548,7 +548,7 @@ static int php_yar_curl_multi_parse_response(yar_curl_multi_data_t *multi, yar_c
 	do {
 		msg = curl_multi_info_read(multi->cm, &msg_in_sequence);
 		if (msg && msg->msg == CURLMSG_DONE) {
-			uint found = 0;
+			unsigned found = 0;
 			yar_transport_interface_t *handle = multi->chs, *q = NULL;
 
 			while (handle) {
@@ -577,7 +577,7 @@ static int php_yar_curl_multi_parse_response(yar_curl_multi_data_t *multi, yar_c
 
 					if(curl_easy_getinfo(data->cp, CURLINFO_RESPONSE_CODE, &http_code) == CURLE_OK && http_code != 200) {
 						char buf[128];
-						uint len = snprintf(buf, sizeof(buf), "server responsed non-200 code '%ld'", http_code);
+						unsigned len = snprintf(buf, sizeof(buf), "server responsed non-200 code '%ld'", http_code);
 
 						php_yar_response_set_error(response, YAR_ERR_TRANSPORT, buf, len);
 

--- a/yar_client.c
+++ b/yar_client.c
@@ -324,7 +324,7 @@ int php_yar_concurrent_client_callback(yar_call_data_t *calldata, int status, ya
 	zval code, retval, retval_ptr;
 	zval callinfo, *callback, *func_params;
 	zend_bool bailout = 0;
-	uint params_count, i;
+	unsigned params_count, i;
 
 	if (calldata) {
 		/* data callback */
@@ -717,7 +717,7 @@ PHP_METHOD(yar_concurrent_client, loop) {
 	zval *callstack;
 	zval *callback = NULL, *error_callback = NULL;
 	zval *status;
-	uint ret = 0;
+	unsigned ret = 0;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|zz", &callback, &error_callback) == FAILURE) {
 		return;

--- a/yar_exception.c
+++ b/yar_exception.c
@@ -62,7 +62,7 @@ zend_class_entry * php_yar_get_exception_base(int root) /* {{{ */ {
 
 void php_yar_error_ex(yar_response_t *response, int type, const char *format, va_list args) /* {{{ */ {
 	char *msg;
-	uint len;
+	unsigned len;
 
 	len = vspprintf(&msg, 0, format, args);
 	php_yar_response_set_error(response, type, msg, len);

--- a/yar_exception.h
+++ b/yar_exception.h
@@ -43,7 +43,7 @@ extern zend_class_entry *yar_client_transport_exception_ce;
 extern zend_class_entry *yar_client_packager_exception_ce;
 extern zend_class_entry *yar_client_protocol_exception_ce;
 
-extern void (*zend_orig_error_cb)(int, const char *, const uint, const char *, va_list);
+extern void (*zend_orig_error_cb)(int, const char *, const unsigned, const char *, va_list);
  
 void php_yar_error_ex(struct _yar_response *response, int type, const char *format, va_list args);
 void php_yar_error(struct _yar_response *response, int type, const char *format, ...);

--- a/yar_protocol.c
+++ b/yar_protocol.c
@@ -30,7 +30,7 @@
 #include <arpa/inet.h>
 #endif
 
-void php_yar_protocol_render(yar_header_t *header, uint id, char *provider, char *token, uint body_len, uint reserved) /* {{{ */ {
+void php_yar_protocol_render(yar_header_t *header, unsigned id, char *provider, char *token, unsigned body_len, unsigned reserved) /* {{{ */ {
 	header->magic_num = htonl(YAR_PROTOCOL_MAGIC_NUM);
 	header->id = htonl(id);
 	header->body_len = htonl(body_len);

--- a/yar_protocol.h
+++ b/yar_protocol.h
@@ -50,7 +50,7 @@ yar_header_t;
 #endif
 
 yar_header_t * php_yar_protocol_parse(char *payload);
-void php_yar_protocol_render(yar_header_t *header, uint id, char *provider, char *token, uint body_len, uint reserved);
+void php_yar_protocol_render(yar_header_t *header, unsigned id, char *provider, char *token, unsigned body_len, unsigned reserved);
 
 #endif	/* PHP_YAR_PROTOCOL_H */
 

--- a/yar_response.c
+++ b/yar_response.c
@@ -41,7 +41,7 @@ void php_yar_response_alter_body(yar_response_t *response, zend_string *body, in
 	response->out = body;
 } /* }}} */
 
-void php_yar_response_set_error(yar_response_t *response, int type, char *message, uint len) /* {{{ */ {
+void php_yar_response_set_error(yar_response_t *response, int type, char *message, unsigned len) /* {{{ */ {
 	ZVAL_STRINGL(&response->err, message, len);
 	response->status = type;
 } /* }}} */

--- a/yar_response.h
+++ b/yar_response.h
@@ -37,7 +37,7 @@ typedef struct _yar_response {
 yar_response_t * php_yar_response_instance();
 int php_yar_response_bind_request(yar_response_t *response, struct _yar_request *request);
 void php_yar_response_alter_body(yar_response_t *response, zend_string *body, int method); 
-void php_yar_response_set_error(yar_response_t *response, int type, char *message, uint len); 
+void php_yar_response_set_error(yar_response_t *response, int type, char *message, unsigned len); 
 void php_yar_response_set_exception(yar_response_t *response, zend_object *ex);
 void php_yar_response_set_retval(yar_response_t *response, zval *retval);
 void php_yar_response_map_retval(yar_response_t *response, zval *ret);


### PR DESCRIPTION
As of PHP 7.4.0, the portable definition of `uint` is no longer
available, so we replace it with `unsigned`.