### PR TITLE
Don't update up-to-date deps

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -103,7 +103,8 @@ build_script:
         #echo "@echo off" | Out-File -Encoding "ASCII" task.bat
         #echo "" | Out-File -Encoding "ASCII" -Append task.bat
         echo "" | Out-File -Encoding "ASCII" task.bat
-        echo "call phpsdk_deps -d c:\build-cache\deps -un" | Out-File -Encoding "ASCII" -Append task.bat
+        echo "call phpsdk_deps -d c:\build-cache\deps -c" | Out-File -Encoding "ASCII" -Append task.bat
+        echo "if errorlevel 7 call phpsdk_deps -d c:\build-cache\deps -un" | Out-File -Encoding "ASCII" -Append task.bat
         echo "call phpize 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
         echo "call configure --with-php-build=c:\build-cache\deps --enable-yar --enable-debug-pack 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
         echo "nmake /nologo 2>&1" | Out-File -Encoding "ASCII" -Append task.bat


### PR DESCRIPTION
Since the PHP build dependencies are cached anyway, we only update them
if there are actually updates available.  This should drastically
improve the required build times.