### PR TITLE
fix #172 provider/token may be not nul terminated

### DIFF
--- a/yar_server.c
+++ b/yar_server.c
@@ -525,8 +525,16 @@ static inline int php_yar_server_auth(zval *obj, yar_header_t *header, yar_respo
 	YAR_TRY {
 		zval auth_params[2];
 
-		ZVAL_STRINGL(&auth_params[0], (char*)header->provider, MIN(strlen(header->provider), 32));
-		ZVAL_STRINGL(&auth_params[1], (char*)header->token, MIN(strlen(header->token), 32));
+		if (memchr(header->provider, 0, 32)) {
+			ZVAL_STRINGL(&auth_params[0], (char*)header->provider, strlen((char *)header->provider));
+		} else {
+			ZVAL_STRINGL(&auth_params[0], (char*)header->provider, 32);
+		}
+		if (memchr(header->token, 0, 32)) {
+			ZVAL_STRINGL(&auth_params[1], (char*)header->token, strlen((char*)header->token));
+		} else {
+			ZVAL_STRINGL(&auth_params[1], (char*)header->token, 32);
+		}
 
 #if PHP_VERSION_ID < 80000
 		zend_call_method_with_2_params(obj, ce, NULL, "__auth", &ret, auth_params, auth_params + 1);


### PR DESCRIPTION
Using this seems to fix #172 


```
=====================================================================
PHP         : /usr/bin/php 
PHP_SAPI    : cli
PHP_VERSION : 7.4.29
ZEND_VERSION: 3.4.0
PHP_OS      : Linux - Linux builder.remirepo.net 5.17.5-200.fc35.x86_64 #1 SMP PREEMPT Thu Apr 28 15:41:41 UTC 2022 x86_64
INI actual  : /builddir/build/BUILD/php-pecl-yar-2.3.0/NTS
More .INIs  :   
CWD         : /builddir/build/BUILD/php-pecl-yar-2.3.0/NTS
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
TIME START 2022-05-05 06:59:56
=====================================================================
PASS Check for yar presence [tests/001.phpt] 
PASS Check for yar server info [tests/002.phpt] 
PASS Check for yar client [tests/003.phpt] 
PASS Check for Yar_Client::setOpt [tests/004.phpt] 
PASS Check for yar client with exception [tests/005.phpt] 
PASS Check for yar concurrent client with exception [tests/006.phpt] 
PASS Check for yar client with output by server [tests/007.phpt] 
PASS Check for yar client with non yar server [tests/008.phpt] 
PASS Check for yar client with 302 response [tests/009.phpt] 
PASS Check for yar debug [tests/010.phpt] 
PASS Check for yar server __auth [tests/011.phpt] 
PASS Check for yar concurrent client with 128 calls [tests/012.phpt] 
PASS Check for yar concurrent client with add call in callback [tests/013.phpt] 
PASS Check for yar concurrent client with loop in callback [tests/014.phpt] 
PASS Check for yar concurrent client with throw exception in callback [tests/015.phpt] 
PASS Check for yar concurrent client with exit in callbacks [tests/016.phpt] 
PASS Check for yar concurrent client with tcp rpc [tests/017.phpt] 
PASS Check for yar server info (comment) [tests/018.phpt] 
PASS Check for yar server info (internal function) [tests/019.phpt] 
PASS Check for yar concurrent client with custom headers [tests/020.phpt] 
PASS Check for YAR_OPT_PERSISTENT [tests/021.phpt] 
PASS Check for tcp protcol [tests/023.phpt] 
PASS Check for setopt on tcp [tests/024.phpt] 
PASS Check for TCP RPC Malfromaled response (Huge body length) [tests/025.phpt] 
PASS Check for TCP RPC Malfromaled response (Malformaled error) [tests/026.phpt] 
PASS Check for TCP RPC Malfromaled response (Not enough payload recved) [tests/027.phpt] 
PASS Check for TCP RPC Malfromaled response (body_len too small) [tests/028.phpt] 
PASS Check for TCP RPC Malfromaled response (incomplete header) [tests/029.phpt] 
PASS Check for TCP RPC Exceptions [tests/030.phpt] 
PASS Check for TCP client with server exit [tests/031.phpt] 
PASS Check for yar client with huge request body [tests/032.phpt] 
PASS Check for YAR_OPT_PROXY [tests/033.phpt] 
PASS Check for Yar_Client::__cosntruct with options [tests/034.phpt] 
PASS Check for yar concurrent reset [tests/035.phpt] 
PASS Check for YAR_OPT_PROVIDER/TOKEN on tcp [tests/036.phpt] 
PASS Check for YAR_OPT_PERSISTENT on tcp [tests/037.phpt] 
PASS Check for YAR_OPT_TIMEOUT on tcp [tests/038.phpt] 
PASS Check for debug on TCP [tests/039.phpt] 
PASS Check for YAR_OPT_PACKAGER on curl [tests/040.phpt] 
PASS Check for timeout of yar concurrent calls [tests/041.phpt] 
PASS Check for maximum calls of yar concurrent call [tests/042.phpt] 
PASS Check for yar server __info [tests/043.phpt] 
PASS Check for yar server __info (public visiblity) [tests/045.phpt] 
PASS Check for yar server __auth (public visiblity) [tests/046.phpt] 
PASS Check for yar server __auth (concurrent call) [tests/047.phpt] 
PASS Check for yar.content_type [tests/049.phpt] 
PASS Check for yar server __auth (throw exception) [tests/050.phpt] 
PASS Check for yar server __auth (exit) [tests/051.phpt] 
PASS Check for yar server __info (throw exception) [tests/052.phpt] 
PASS Check for yar server __info (return none string) [tests/053.phpt] 
PASS Check for yar server __info (exit) [tests/054.phpt] 
PASS Bug #74867 (segment fault when use yar persistent call twice remote function) [tests/bug74867.phpt] 
=====================================================================
TIME END 2022-05-05 06:59:59

=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   17
---------------------------------------------------------------------

Number of tests :   52                52
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :   52 (100.0%) (100.0%)
---------------------------------------------------------------------
Time taken      :    3 seconds
=====================================================================

```