### PR TITLE
use zend_ce_exception instead of zend_exception_get_default() for 8.5

### DIFF
--- a/yar_exception.c
+++ b/yar_exception.c
@@ -62,7 +62,7 @@ zend_class_entry * php_yar_get_exception_base(int root) /* {{{ */ {
 	}
 #endif
 
-	return zend_exception_get_default();
+	return zend_ce_exception;
 }
 /* }}} */
 


### PR DESCRIPTION
* `zend_ce_exception` available since 7.0
* `zend_exception_get_default` removed in 8.5