### PR TITLE
remove report_memleaks deprecated in 8.5

### DIFF
--- a/tests/042.phpt
+++ b/tests/042.phpt
@@ -6,8 +6,6 @@ if (!extension_loaded("yar")) {
     print "skip";
 }
 ?>
---INI--
-report_memleaks=0
 --FILE--
 <?php 
 include "yar.inc";


### PR DESCRIPTION
```
========DIFF========
001+ Deprecated: PHP Startup: Directive 'report_memleaks' is deprecated in Unknown on line 0
002+ 
     Warning: Yar_Concurrent_Client::call(): too many calls, maximum '128' are allowed in %s042.php on line %d
     
     Warning: Yar_Concurrent_Client::call(): too many calls, maximum '128' are allowed in %s042.php on line %d
========DONE========
FAIL Check for maximum calls of yar concurrent call [tests/042.phpt] 

```