### PR TITLE
docs(README): add lua-yar to third-party clients list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Yar - Yet Another RPC framework for PHP
 [![Build status](https://ci.appveyor.com/api/projects/status/syhw33wlt2nad64i/branch/master?svg=true)](https://ci.appveyor.com/project/laruence/yar/branch/master) [![Build Status](https://github.com/laruence/yar/workflows/integrate/badge.svg)](https://github.com/laruence/yar/actions?query=workflow%3Aintegrate)
 
-Light, concurrent RPC framework for PHP(see also: [Yar C framework](https://github.com/laruence/yar-c), [Yar Java framework](https://github.com/weibocom/yar-java))
+Light, concurrent RPC framework for PHP(see also: [Yar C framework](https://github.com/laruence/yar-c), [Yar Java framework](https://github.com/weibocom/yar-java), [Lua Yar framework](https://github.com/fangfengxiang/lua-yar))
 
 ## Requirement
 - PHP 7.0+  (master branch))


### PR DESCRIPTION
## 背景

感谢鸟哥（@laruence）开源了 Yar 这样优秀的 RPC 框架。
我在工作中需要在 OpenResty/Lua 环境下调用现有的 PHP Yar 服务，
但发现社区缺少一个成熟、零依赖的 Lua 侧实现。

因此我基于 Yar 二进制协议规范，实现了一个纯 Lua 的 Yar 客户端/服务端
框架 —— lua-yar，希望能为 Yar 生态补上一块拼图。

后续愿景：目前希望基于这个Lua-Yar的项目，在OpenResty生态下开发一个微服务网关，主要功能是可以作为grpc to yar 的转换网关，并且作为PHP-FPM前置代理，完善Yar的微服务生态周边，提供代理服务发现注册，链路追踪等提升可观测性等。

以上，如有不当，还请前辈多多指教。

## 修改内容

在 README 中新增 "Third-party Clients" 小节，将 lua-yar 列入
跨语言客户端列表。

## lua-yar 简介

- 纯 Lua 实现，零外部依赖（仅需 luasocket 或 ngx.socket）
- 严格遵循 Yar 二进制协议，与 PHP/C/Java Yar 服务互通
- 协程友好，支持 OpenResty / Skynet / lua-eco 等 Lua 宿主环境
- 多传输协议：TCP / HTTP / Unix Socket
- 内置 JSON / Msgpack 编解码器，支持自定义 packager
- 已发布到 LuaRocks：luarocks install lua-yar

<img width="844" height="450" alt="image" src="https://github.com/user-attachments/assets/3a002671-7fc5-4b1a-9150-829f22c3ac8f" />

示例：
```
server {
    listen 8888;
    location /api {
        content_by_lua_block {
            local Yar = require "yar"
            -- OpenResty uses content_by_lua callback mode: no socket, no HttpServer transport layer
            local server = Yar.server.new({
                add = function(a, b) return a + b end,
            })
            ngx.req.read_body()
            server:handle({
                method = ngx.req.get_method(),
                data = ngx.req.get_body_data() or "",
                writer = function(status, headers, body)
                    ngx.status = status
                    for k, v in pairs(headers) do ngx.header[k] = v end
                    ngx.print(body)
                end,
            })
        }
    }
}
```

## 架构设计
<img width="743" height="591" alt="image" src="https://github.com/user-attachments/assets/15441206-f81e-4667-8027-fbbf7b0e9a8b" />


## 验证与兼容性

- 已通过集成测试验证与 PHP Yar PECL 扩展的协议互通性
- 支持 Lua 5.1 / 5.3 / LuaJIT 2.1 / OpenResty 1.7+

<img width="713" height="475" alt="image" src="https://github.com/user-attachments/assets/28a35746-e2fb-45a5-8b1a-68e093c99306" />

<img width="730" height="379" alt="image" src="https://github.com/user-attachments/assets/7bc81af0-bbe0-4262-bee1-cbae4f35f0f6" />


## 对 Yar 生态的意义

lua-yar 填补了 Yar 在 Lua 嵌入式场景（如 OpenResty 网关、
Skynet 游戏服）的空白，让 PHP 后端与 Lua 前端可以无缝 RPC 通信，
无需引入 gRPC/Thrift 等重型方案。

## 备注

完全尊重鸟哥对 README 内容的决定权。
如果格式或位置不合适，我很乐意按您的建议调整。

---
相关链接：
- GitHub: https://github.com/fangfengxiang/lua-yar
- 文档站: https://fangfengxiang.github.io/lua-yar/
- LuaRocks: https://luarocks.org/modules/fangfengxiang/lua-yar