### PR TITLE
Fix build with PHP 8.6.0alpha3

### DIFF
--- a/yar_client.c
+++ b/yar_client.c
@@ -762,7 +762,7 @@ static HashTable *yar_client_get_gc(void *object, zval **table, int *n) /* {{{ *
 static zend_object *yar_client_new(zend_class_entry *ce) /* {{{ */ {
 	yar_client_object *client = emalloc(sizeof(yar_client_object) + zend_object_properties_size(ce));
 
-	memset(client, 0, XtOffsetOf(yar_client_object, std));
+	memset(client, 0, offsetof(yar_client_object, std));
 	zend_object_std_init(&client->std, ce);
 
 	if (ce->default_properties_count) {
@@ -780,7 +780,11 @@ PHP_METHOD(yar_client, __construct) {
 	zval *options = NULL;
 	yar_client_object *client = Z_YARCLIENTOBJ_P(getThis());
 
+#if PHP_VERSION_ID < 80600
     if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "S|a!", &url, &options) == FAILURE) {
+#else
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|a!", &url, &options) == FAILURE) {
+#endif
         return;
     }
 
@@ -1065,7 +1069,7 @@ YAR_STARTUP_FUNCTION(client) /* {{{ */ {
 	yar_client_ce->create_object = yar_client_new;
 
 	memcpy(&yar_client_obj_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
-	yar_client_obj_handlers.offset = XtOffsetOf(yar_client_object, std);
+	yar_client_obj_handlers.offset = offsetof(yar_client_object, std);
 	yar_client_obj_handlers.free_obj = yar_client_object_free;
 	yar_client_obj_handlers.get_properties = (zend_object_get_properties_t)yar_client_get_properties;
 	yar_client_obj_handlers.get_gc = (zend_object_get_gc_t)yar_client_get_gc;

--- a/yar_client.h
+++ b/yar_client.h
@@ -41,7 +41,7 @@ typedef struct {
 #define Z_YARCLIENTOBJ_P(z)  Z_YARCLIENTOBJ((*z))
 
 static zend_always_inline yar_client_object *php_yar_client_fetch_object(zend_object *obj) {
-	return (yar_client_object *)((char*)(obj) - XtOffsetOf(yar_client_object, std));
+	return (yar_client_object *)((char*)(obj) - offsetof(yar_client_object, std));
 }
 
 YAR_STARTUP_FUNCTION(client);

--- a/yar_server.c
+++ b/yar_server.c
@@ -789,7 +789,11 @@ response:
 PHP_METHOD(yar_server, __construct) {
     zval *obj;
 
+#if PHP_VERSION_ID < 80600
     if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "o", &obj) == FAILURE) {
+#else
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "o", &obj) == FAILURE) {
+#endif
         return;
     }
 


### PR DESCRIPTION
```
  . The XtOffsetOf() alias of C’s offsetof() macro has been removed. Use
    offsetof() directly.

  . The zend_parse_parameters_none_throw(), zend_parse_parameters_throw(),
    and ZEND_PARSE_PARAMS_THROW have been removed due to being misleading,
    since ZPP always throws, unless ZEND_PARSE_PARAMS_QUIET is given. Use
    the non-throw versions.

```
Keep zend_parse_parameters_throw for PHP 7

This fix the build, but 1 test still failing

```
TEST 41/73 [tests/041.phpt]
========DIFF========
001- Warning: Yar_Concurrent_Client::loop(): %rselect|epoll_wait%r timeout '100ms' reached in %s041.php on line %d
001+ Warning: Yar_Concurrent_Client::loop(): [16] Timeout was reached in /work/GIT/pecl-and-ext/yar/tests/041.php on line 10
002+ 
003+ Warning: Yar_Concurrent_Client::loop(): [16] Timeout was reached in /work/GIT/pecl-and-ext/yar/tests/041.php on line 10
004+ 
005+ Warning: Yar_Concurrent_Client::loop(): [16] Timeout was reached in /work/GIT/pecl-and-ext/yar/tests/041.php on line 10
006+ 
007+ Warning: Yar_Concurrent_Client::loop(): [16] Timeout was reached in /work/GIT/pecl-and-ext/yar/tests/041.php on line 10
008+ 
009+ Warning: Yar_Concurrent_Client::loop(): [16] Timeout was reached in /work/GIT/pecl-and-ext/yar/tests/041.php on line 10
010+ 
011+ Warning: Yar_Concurrent_Client::loop(): [16] Timeout was reached in /work/GIT/pecl-and-ext/yar/tests/041.php on line 10
012+ 
013+ Warning: Yar_Concurrent_Client::loop(): [16] Timeout was reached in /work/GIT/pecl-and-ext/yar/tests/041.php on line 10
014+ 
015+ Warning: Yar_Concurrent_Client::loop(): [16] Timeout was reached in /work/GIT/pecl-and-ext/yar/tests/041.php on line 10
========DONE========
FAIL Check for timeout of yar concurrent calls [tests/041.phpt] 

```